### PR TITLE
🐛 Fix: 사진 배열이 비었을 때 발생하는 오류 수정

### DIFF
--- a/src/main/java/com/telegro/telegro/domain/product/service/ProductService.java
+++ b/src/main/java/com/telegro/telegro/domain/product/service/ProductService.java
@@ -55,10 +55,14 @@ public class ProductService {
         Product savedProduct = productRepository.save(product);
 
         // 대표 이미지가 없으면 등록한 사진 중 첫번째가 대표 이미지가 됨
-        if(request.coverImage() !=null){
-            savedProduct.setCoverImage(request.coverImage());
+        if (request.pictures().isEmpty()) {
+            if(request.coverImage() !=null){
+                savedProduct.setCoverImage(request.coverImage());
+            } else {
+                savedProduct.setCoverImage(request.pictures().get(0));
+            }
         } else {
-            savedProduct.setCoverImage(request.pictures().get(0));
+            savedProduct.setCoverImage(null);
         }
 
         return CreatedProductDTO.builder()


### PR DESCRIPTION
사진 배열이 비었을 때 대표 이미지를 null로 처리

## #️⃣연관된 이슈

> #4 

## 📝작업 내용

> pictures 배열이 null일 때의 처리를 안해줘서 대표이미지 설정 시 pictures 배열을 참조하면서 Index 0 out of bounds for length 0 오류 발생
.isEmpty 처리를 해줘서 해결
